### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/vulnerabilities/importers/openssl.py
+++ b/vulnerabilities/importers/openssl.py
@@ -78,7 +78,8 @@ def to_advisory_data(xml_issue) -> AdvisoryData:
 
         elif info.tag == "advisory":
             advisory_url = info.attrib["url"]
-            if not advisory_url.startswith("https://web.archive.org"):
+            parsed_url = urlparse(advisory_url)
+            if parsed_url.hostname != "web.archive.org":
                 advisory_url = urljoin("https://www.openssl.org", advisory_url)
 
         elif info.tag == "cve":


### PR DESCRIPTION
Potential fix for [https://github.com/SolidifyDemo/ghas-vulnerable-python-template/security/code-scanning/5](https://github.com/SolidifyDemo/ghas-vulnerable-python-template/security/code-scanning/5)

To fix the issue, the URL should be parsed using `urlparse` from the `urllib.parse` module, and the hostname should be explicitly checked to ensure it matches `web.archive.org`. This approach ensures that the check is performed on the actual domain of the URL, rather than relying on substring matching.

**Steps to implement the fix:**
1. Parse the `advisory_url` using `urlparse`.
2. Extract the hostname from the parsed URL.
3. Check if the hostname matches `web.archive.org`.
4. Update the logic to handle cases where the hostname does not match.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
